### PR TITLE
feat: estruturar projeto npm com separação de CSS e JS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1921 @@
+{
+  "name": "escalas-feriados",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "escalas-feriados",
+      "version": "1.0.0",
+      "devDependencies": {
+        "lite-server": "^2.6.1"
+      }
+    },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.2.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.2.1.tgz",
+      "integrity": "sha512-DRh5K+ka5eJic8CjH7td8QpYEV6Zo10gfRkjHCO3weqZHWDtAaSTFtl4+VMqOJ4N5jcuhZ9/l+yy8rVgw7BQeQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.10.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/async": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.14"
+      }
+    },
+    "node_modules/async-each-series": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/async-each-series/-/async-each-series-0.1.1.tgz",
+      "integrity": "sha512-p4jj6Fws4Iy2m0iCmI2am2ZNZCgbdgE+P8F/8csmn2vx7ixXrO2zGcuNsD46X5uZSVecmkEy/M06X2vG8KD6dQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.14.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/base64id": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^4.5.0 || >= 5.9"
+      }
+    },
+    "node_modules/batch": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
+      "integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browser-sync": {
+      "version": "2.29.3",
+      "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.29.3.tgz",
+      "integrity": "sha512-NiM38O6XU84+MN+gzspVmXV2fTOoe+jBqIBx3IBdhZrdeURr6ZgznJr/p+hQ+KzkKEiGH/GcC4SQFSL0jV49bg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "browser-sync-client": "^2.29.3",
+        "browser-sync-ui": "^2.29.3",
+        "bs-recipes": "1.3.4",
+        "chalk": "4.1.2",
+        "chokidar": "^3.5.1",
+        "connect": "3.6.6",
+        "connect-history-api-fallback": "^1",
+        "dev-ip": "^1.0.1",
+        "easy-extender": "^2.3.4",
+        "eazy-logger": "^4.0.1",
+        "etag": "^1.8.1",
+        "fresh": "^0.5.2",
+        "fs-extra": "3.0.1",
+        "http-proxy": "^1.18.1",
+        "immutable": "^3",
+        "localtunnel": "^2.0.1",
+        "micromatch": "^4.0.2",
+        "opn": "5.3.0",
+        "portscanner": "2.2.0",
+        "raw-body": "^2.3.2",
+        "resp-modifier": "6.0.2",
+        "rx": "4.1.0",
+        "send": "0.16.2",
+        "serve-index": "1.9.1",
+        "serve-static": "1.13.2",
+        "server-destroy": "1.0.1",
+        "socket.io": "^4.4.1",
+        "ua-parser-js": "^1.0.33",
+        "yargs": "^17.3.1"
+      },
+      "bin": {
+        "browser-sync": "dist/bin.js"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/browser-sync-client": {
+      "version": "2.29.3",
+      "resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-2.29.3.tgz",
+      "integrity": "sha512-4tK5JKCl7v/3aLbmCBMzpufiYLsB1+UI+7tUXCCp5qF0AllHy/jAqYu6k7hUF3hYtlClKpxExWaR+rH+ny07wQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "etag": "1.8.1",
+        "fresh": "0.5.2",
+        "mitt": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/browser-sync-ui": {
+      "version": "2.29.3",
+      "resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-2.29.3.tgz",
+      "integrity": "sha512-kBYOIQjU/D/3kYtUIJtj82e797Egk1FB2broqItkr3i4eF1qiHbFCG6srksu9gWhfmuM/TNG76jMfzAdxEPakg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "async-each-series": "0.1.1",
+        "chalk": "4.1.2",
+        "connect-history-api-fallback": "^1",
+        "immutable": "^3",
+        "server-destroy": "1.0.1",
+        "socket.io-client": "^4.4.1",
+        "stream-throttle": "^0.1.3"
+      }
+    },
+    "node_modules/bs-recipes": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/bs-recipes/-/bs-recipes-1.3.4.tgz",
+      "integrity": "sha512-BXvDkqhDNxXEjeGM8LFkSbR+jzmP/CYpCiVKYn+soB1dDldeU15EBNDkwVXndKuX35wnNUaPd0qSoQEAkmQtMw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/connect": {
+      "version": "3.6.6",
+      "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.6.tgz",
+      "integrity": "sha512-OO7axMmPpu/2XuX1+2Yrg0ddju31B6xLZMWkJ5rYBu4YRmRVlOjvlY6kw2FJKiAzyxGwnrDUAG4s1Pf0sbBMCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "finalhandler": "1.1.0",
+        "parseurl": "~1.3.2",
+        "utils-merge": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/connect-history-api-fallback": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
+      "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/connect-logger": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/connect-logger/-/connect-logger-0.0.1.tgz",
+      "integrity": "sha512-kC5FPWpcfgpW5HtICnXbdOAFa4uNilU4ZPmsH6RlXaDVfXLupyUjgI1otpj3kOcsoPpDxknxmcoM0wk0ApsjYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "moment": "*"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha512-3NdhDuEXnfun/z7x9GOElY49LoqVHoGScmOKwmxhsS8N5Y+Z8KyPPDnaSzqWgYt/ji4mqwfTS34Htrk0zPIXVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dev-ip": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dev-ip/-/dev-ip-1.0.1.tgz",
+      "integrity": "sha512-LmVkry/oDShEgSZPNgqCIp2/TlqtExeGmymru3uCELnfyjY11IzpAproLYs+1X88fXO6DBoYP3ul2Xo2yz2j6A==",
+      "dev": true,
+      "bin": {
+        "dev-ip": "lib/dev-ip.js"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/easy-extender": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/easy-extender/-/easy-extender-2.3.4.tgz",
+      "integrity": "sha512-8cAwm6md1YTiPpOvDULYJL4ZS6WfM5/cTeVVh4JsvyYZAoqlRVUpHL9Gr5Fy7HA6xcSZicUia3DeAgO3Us8E+Q==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.10"
+      },
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/eazy-logger": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eazy-logger/-/eazy-logger-4.1.0.tgz",
+      "integrity": "sha512-+mn7lRm+Zf1UT/YaH8WXtpU6PIV2iOjzP6jgKoiaq/VNrjYKp+OHZGe2znaLgDeFkw8cL9ffuaUm+nNnzcYyGw==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "4.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/engine.io": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.4.tgz",
+      "integrity": "sha512-ZCkIjSYNDyGn0R6ewHDtXgns/Zre/NT6Agvq1/WobF7JXgFff4SeDroKiCO3fNJreU9YG429Sc81o4w5ok/W5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/cors": "^2.8.12",
+        "@types/node": ">=10.0.0",
+        "accepts": "~1.3.4",
+        "base64id": "2.0.0",
+        "cookie": "~0.7.2",
+        "cors": "~2.8.5",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.17.1"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/engine.io-client": {
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.3.tgz",
+      "integrity": "sha512-T0iLjnyNWahNyv/lcjS2y4oE358tVS/SYQNxYXGAJ9/GLgH4VCvOQ/mhTjqU88mLZCQgiG8RIegFHYCdVC+j5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.17.1",
+        "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
+    "node_modules/engine.io-client/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io-client/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/engine.io/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
+      "integrity": "sha512-ejnvM9ZXYzp6PUPUyQBMBf0Co5VX2gr5H2VQe2Ui2jWXNlxv+PYZo8wpAymJNJdLsG1R4p+M4aynF8KuoUEwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "statuses": "~1.3.1",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
+      "integrity": "sha512-V3Z3WZWVUYd8hoCL5xfXJCaHWYzmtwW5XWYSlLgERi8PWd8bx1kUHUk8L1BT57e49oKnDDD180mjfrHc1yA9rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^3.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-errors/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-proxy": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/immutable": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
+      "integrity": "sha512-15gZoQ38eYjEjxkorfbcgBKBL6R7T459OuK+CpcWt7O3KF4uPCx2tD0uFETlUDIyo+1789crbMhTvQBSR5yBMg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-number-like": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/is-number-like/-/is-number-like-1.0.8.tgz",
+      "integrity": "sha512-6rZi3ezCyFcn5L71ywzz2bS5b2Igl1En3eTlZlvKjpz1n3IZLAYMbKYAIQgFmEu0GENg92ziU/faEOA/aixjbA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lodash.isfinite": "^3.3.2"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+      "integrity": "sha512-gfygJYZ2gLTDlmbWMI0CE2MwnFzSN/2SZfkMlItC4K/JBlsWVDB0bO6XhqcY13YXE7iMcAJnzTCJjPiTeJJ0Mw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
+      "integrity": "sha512-oBko6ZHlubVB5mRFkur5vgYR1UyqX+S6Y/oCfLhqNdcc2fYFlDpIoNc7AfKS1KOGcnNAkvsr0grLck9ANM815w==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/limiter": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
+      "integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA==",
+      "dev": true
+    },
+    "node_modules/lite-server": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/lite-server/-/lite-server-2.6.1.tgz",
+      "integrity": "sha512-d3oyB/C8AU4EwYQHlLxcu6vTQDnCaLb81v1KKNYABmFS5oeJ11A+YxlqtpbTclID1AFddJfcB5klf0q98vYIMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "browser-sync": "^2.26.13",
+        "connect-history-api-fallback": "^1.6.0",
+        "connect-logger": "^0.0.1",
+        "lodash": "^4.17.20",
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "lite-server": "bin/lite-server"
+      }
+    },
+    "node_modules/localtunnel": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/localtunnel/-/localtunnel-2.0.2.tgz",
+      "integrity": "sha512-n418Cn5ynvJd7m/N1d9WVJISLJF/ellZnfsLnx8WBWGzxv/ntNcFkJ1o6se5quUhCplfLGBNL5tYHiq5WF3Nug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "axios": "0.21.4",
+        "debug": "4.3.2",
+        "openurl": "1.1.1",
+        "yargs": "17.1.1"
+      },
+      "bin": {
+        "lt": "bin/lt.js"
+      },
+      "engines": {
+        "node": ">=8.3.0"
+      }
+    },
+    "node_modules/localtunnel/node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/localtunnel/node_modules/debug": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/localtunnel/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/localtunnel/node_modules/yargs": {
+      "version": "17.1.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.1.1.tgz",
+      "integrity": "sha512-c2k48R0PwKIqKhPMWjeiF6y2xY/gPMUlro0sgxqXpbOIohWiLNXWslsootttv7E1e73QPAMQSg5FeySbVcpsPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/localtunnel/node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isfinite": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz",
+      "integrity": "sha512-7FGG40uhC8Mm633uKW1r58aElFlBlxCrg9JfSi3P6aYiWmfiWF0PgMd86ZUsxE5GwWPdHoS2+48bwTh2VPkIQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mitt": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-1.2.0.tgz",
+      "integrity": "sha512-r6lj77KlwqLhIUku9UWYes7KJtsczvolZkzp8hbaDPPaE24OmWl5s539Mytlj22siEQKosZ26qCBgda2PKwoJw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/openurl": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/openurl/-/openurl-1.1.1.tgz",
+      "integrity": "sha512-d/gTkTb1i1GKz5k3XE3XFV/PxQ1k45zDqGP2OA7YhgsaLoqm6qRvARAZOFer1fcXritWlGBRCu/UgeS4HAnXAA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/opn": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
+      "integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/portscanner": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/portscanner/-/portscanner-2.2.0.tgz",
+      "integrity": "sha512-IFroCz/59Lqa2uBvzK3bKDbDDIEaAY8XJ1jFxcLWTqosrsc32//P4VuSB2vZXoHiHqOmx8B5L5hnKOxL/7FlPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async": "^2.6.0",
+        "is-number-like": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=0.4",
+        "npm": ">=1.0.0"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/resp-modifier": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/resp-modifier/-/resp-modifier-6.0.2.tgz",
+      "integrity": "sha512-U1+0kWC/+4ncRFYqQWTx/3qkfE6a4B/h3XXgmXypfa0SPZ3t7cbbaFk297PjQS/yov24R18h6OZe6iZwj3NSLw==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^2.2.0",
+        "minimatch": "^3.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/rx": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
+      "integrity": "sha512-CiaiuN6gapkdl+cZUr67W6I8jquN4lkak3vtIsIWCl4XIPP8ffsoyN6/+PuGXnQy8Cu8W2y9Xxh31Rq4M6wUug==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
+      "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "~1.6.2",
+        "mime": "1.4.1",
+        "ms": "2.0.0",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/send/node_modules/http-errors": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "integrity": "sha512-lks+lVC8dgGyh97jxvxeYTWQFvh4uw4yC12gVl63Cg30sjPX4wuGcdkICVXDAESr6OJGjqGA8Iz5mkeN6zlD7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.0",
+        "statuses": ">= 1.4.0 < 2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/send/node_modules/inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/send/node_modules/setprototypeof": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/send/node_modules/statuses": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+      "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/serve-index": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
+      "integrity": "sha512-pXHfKNP4qujrtteMrSBb0rc8HJ9Ms/GrXwcUtUtD5s4ewDJI8bT3Cz2zTVRMKtri49pLx2e0Ya8ziP5Ya2pZZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.4",
+        "batch": "0.6.1",
+        "debug": "2.6.9",
+        "escape-html": "~1.0.3",
+        "http-errors": "~1.6.2",
+        "mime-types": "~2.1.17",
+        "parseurl": "~1.3.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/serve-index/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/serve-index/node_modules/http-errors": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "integrity": "sha512-lks+lVC8dgGyh97jxvxeYTWQFvh4uw4yC12gVl63Cg30sjPX4wuGcdkICVXDAESr6OJGjqGA8Iz5mkeN6zlD7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.0",
+        "statuses": ">= 1.4.0 < 2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/serve-index/node_modules/inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/serve-index/node_modules/setprototypeof": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/serve-index/node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
+      "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.2",
+        "send": "0.16.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/server-destroy": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/server-destroy/-/server-destroy-1.0.1.tgz",
+      "integrity": "sha512-rb+9B5YBIEzYcD6x2VKidaa+cqYBJQKnU4oe4E3ANwRRN56yk/ua1YCJT1n21NTS8w6CcOclAKNP3PhdCXKYtQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/socket.io": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.1.tgz",
+      "integrity": "sha512-oZ7iUCxph8WYRHHcjBEc9unw3adt5CmSNlppj/5Q4k2RIrhl8Z5yY2Xr4j9zj0+wzVZ0bxmYoGSzKJnRl6A4yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.4",
+        "base64id": "~2.0.0",
+        "cors": "~2.8.5",
+        "debug": "~4.3.2",
+        "engine.io": "~6.6.0",
+        "socket.io-adapter": "~2.5.2",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/socket.io-adapter": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.5.tgz",
+      "integrity": "sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "~4.3.4",
+        "ws": "~8.17.1"
+      }
+    },
+    "node_modules/socket.io-adapter/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io-adapter/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/socket.io-client": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.1.tgz",
+      "integrity": "sha512-hJVXfu3E28NmzGk8o1sHhN3om52tRvwYeidbj7xKy2eIIse5IoKX3USlS6Tqt3BHAtflLIkCQBkzVrEEfWUyYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.2",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-client/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io-client/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
+      "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io-parser/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/socket.io/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+      "integrity": "sha512-wuTCPGlJONk/a1kqZ4fQM2+908lC7fa7nPYpTC1EhnvqLX/IICbeP1OZGDtA374trpSq68YubKUMo8oRhN46yg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/stream-throttle": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/stream-throttle/-/stream-throttle-0.1.3.tgz",
+      "integrity": "sha512-889+B9vN9dq7/vLbGyuHeZ6/ctf5sNuGWsDy89uNxkFTAgzy0eK7+w5fL3KLNRTkLle7EgZGvHUphZW0Q26MnQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "commander": "^2.2.0",
+        "limiter": "^1.0.5"
+      },
+      "bin": {
+        "throttleproxy": "bin/throttleproxy.js"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/ua-parser-js": {
+      "version": "1.0.40",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.40.tgz",
+      "integrity": "sha512-z6PJ8Lml+v3ichVojCiB8toQJBuwR42ySM4ezjXIqXK3M0HczmKQ3LF4rhU55PfD99KEEXQG6yb7iOMyvYuHew==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "ua-parser-js": "script/cli.js"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "escalas-feriados",
+  "version": "1.0.0",
+  "description": "Escalas & Feriados web app",
+  "type": "module",
+  "scripts": {
+    "start": "lite-server --baseDir src",
+    "test": "echo \"No tests\""
+  },
+  "devDependencies": {
+    "lite-server": "^2.6.1"
+  }
+}

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -1,0 +1,66 @@
+:root{
+    --bg:#0f1221; --card:#171a2b; --muted:#9aa3b2; --text:#e8ecf2;
+    --brand:#6c7cff; --brand-2:#28d7a4; --danger:#ff6b6b; --warn:#ffb020;
+    --grid:#252a3f; --holiday:#36233d; --shadow:0 8px 30px rgba(0,0,0,.25);
+    --radius:12px;
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:linear-gradient(180deg,#0b0e1a,#12162a);color:var(--text);font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif}
+  header{display:flex;gap:.75rem;align-items:center;justify-content:space-between;padding:1rem 1.2rem;border-bottom:1px solid #1f2440;position:sticky;top:0;background:#0f1221d9;backdrop-filter: blur(6px);z-index:10}
+  .brand{display:flex;gap:.6rem;align-items:center}
+  .brand .logo{width:34px;height:34px;border-radius:10px;background:linear-gradient(135deg,var(--brand),#9b6cff);display:grid;place-items:center;color:white;font-weight:700;box-shadow:var(--shadow)}
+  .controls{display:flex;flex-wrap:wrap;gap:.5rem;align-items:center}
+  .btn{border:1px solid #2a3154;background:#161a30;color:var(--text);padding:.55rem .8rem;border-radius:10px;cursor:pointer;transition:.15s;box-shadow:0 2px 0 #0b0e1a}
+  .btn:hover{transform:translateY(-1px);background:#1d2140}
+  .btn.primary{background:linear-gradient(135deg,var(--brand),#9b6cff);border:none}
+  .btn.ghost{background:transparent;border:1px dashed #2a3154}
+  .btn-group{display:flex;border:1px solid #2a3154;border-radius:12px;overflow:hidden}
+  .btn-tab{background:#151931;border:none;padding:.5rem .9rem;cursor:pointer;color:#c7cbe0}
+  .btn-tab.active{background:#27305b;color:#fff}
+  select, input[type="date"], input[type="text"], textarea, input[type="number"]{
+    background:#12162a;border:1px solid #2a3154;color:var(--text);padding:.55rem .7rem;border-radius:10px;outline:none;min-width:140px
+  }
+  main{max-width:1200px;margin:1rem auto;padding:0 1rem 2rem}
+  .calendar{background:var(--card);border:1px solid #222846;border-radius:var(--radius);overflow:hidden;box-shadow:var(--shadow)}
+  .cal-header{display:flex;justify-content:space-between;align-items:center;padding:1rem;border-bottom:1px solid #202643}
+  .cal-grid{display:grid;grid-template-columns:repeat(7,1fr);gap:1px;background:var(--grid)}
+  .cal-cell{background:#11162b;min-height:110px;padding:.6rem;position:relative;cursor:pointer}
+  .cal-cell .date{font-weight:600;color:#c9d2ea;font-size:.92rem}
+  .cal-cell .badges{position:absolute;left:.6rem;bottom:.6rem;display:flex;gap:.35rem;flex-wrap:wrap}
+  .badge{font-size:.72rem;padding:.15rem .4rem;border-radius:8px;border:1px solid #2a3154;color:#cfd6e9;background:#151a31}
+  .badge.holiday{background:var(--holiday);border-color:#5b375f;color:#f1c1ff}
+  .badge.work{background:#1b2f2a;border-color:#1f5f53;color:#a7f3d0}
+  .badge.off{background:#2b243a;border-color:#4b3f6a;color:#d7c5ff}
+  .cal-weekdays{display:grid;grid-template-columns:repeat(7,1fr);background:#141a33;border-bottom:1px solid #202643}
+  .cal-weekdays div{padding:.6rem;text-align:center;color:#96a0bb;font-weight:600}
+  .muted{color:#9aa3b2}
+  .today{outline:2px solid var(--brand);outline-offset:-2px;border-radius:8px}
+  .side{margin-top:1rem;display:grid;grid-template-columns:1.1fr .9fr;gap:1rem}
+  @media(max-width:960px){.side{grid-template-columns:1fr}}
+  .panel{background:var(--card);border:1px solid #222846;border-radius:var(--radius);padding:1rem;box-shadow:var(--shadow)}
+  .panel h3{margin:.2rem 0 1rem;font-size:1.05rem}
+  .list{display:flex;flex-direction:column;gap:.5rem}
+  .row{display:flex;gap:.6rem;align-items:center;justify-content:space-between;background:#11162b;border:1px solid #242a48;padding:.6rem .7rem;border-radius:10px}
+  .pill{padding:.2rem .5rem;border-radius:999px;font-size:.75rem;border:1px solid #2a3154;color:#cfd6e9}
+  .pill.ok{background:#113226;border-color:#1e5e4c;color:#c7ffe9}
+  .pill.warn{background:#3a2b13;border-color:#6c5420;color:#ffd88a}
+  .pill.wait{background:#2b2b38;border-color:#484a78;color:#cbd0ff}
+  .kbd{font-family:ui-monospace, SFMono-Regular, Menlo, monospace;background:#1a1f36;padding:.1rem .35rem;border-radius:6px;border:1px solid #2a3154;color:#cbd3ea}
+  .split{display:flex;gap:.6rem;align-items:center;flex-wrap:wrap}
+  .right{margin-left:auto}
+  .grid2{display:grid;grid-template-columns:1fr 1fr;gap:.6rem}
+  .grid3{display:grid;grid-template-columns:repeat(3,1fr);gap:.6rem}
+  .label{font-size:.78rem;color:var(--muted);margin-bottom:.2rem}
+  .empty{color:#99a2bd;text-align:center;padding:1rem 0}
+  .settings{display:none;position:fixed;inset:0;background:rgba(0,0,0,.45);align-items:flex-end;justify-content:center;z-index:60}
+  .sheet{width:min(840px,96vw);background:var(--card);border:1px solid #222846;border-radius:16px 16px 0 0;padding:1rem 1rem 1.2rem;box-shadow:var(--shadow)}
+  #loginOverlay{position:fixed;inset:0;background:linear-gradient(160deg,#0b0e1a,#141a33);display:none;align-items:center;justify-content:center;z-index:200}
+  .loginCard{width:min(520px,92vw);background:var(--card);border:1px solid #222846;border-radius:16px;padding:1.2rem;box-shadow:var(--shadow)}
+  table{width:100%;border-collapse:separate;border-spacing:0}
+  th,td{padding:.55rem .6rem;border-bottom:1px solid #242a48}
+  thead th{position:sticky;top:0;background:#151a31;border-bottom:1px solid #293059;z-index:1}
+  tr:hover td{background:#101631}
+  .tag{display:inline-block;padding:.18rem .45rem;border-radius:8px;font-size:.75rem;border:1px solid #2a3154}
+  .tag.work{background:#10261f;border-color:#1a4b3b;color:#9debd3}
+  .tag.off{background:#20163a;border-color:#3d2d64;color:#e0d4ff}
+  .tag.hol{background:#2a1b2e;border-color:#52334f;color:#f3ccff}

--- a/src/index.html
+++ b/src/index.html
@@ -1,0 +1,187 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+<title>Escalas & Feriados • Folgas</title>
+<link rel="stylesheet" href="./css/styles.css">
+</head>
+<body>
+  <header>
+    <div class="brand">
+      <div class="logo">EF</div>
+      <div>
+        <div style="font-weight:700">Escalas & Feriados</div>
+        <div style="font-size:.85rem;color:#9aa3b2">Folgas • Trocas • Calendário</div>
+      </div>
+    </div>
+
+    <div class="controls">
+      <button class="btn" id="prevBtn">◀</button>
+      <div id="currentLabel" class="kbd"></div>
+      <button class="btn" id="nextBtn">▶</button>
+
+      <div class="btn-group" role="tablist" aria-label="Mudar visualização">
+        <button class="btn-tab active" data-view="month">Mensal</button>
+        <button class="btn-tab" data-view="week">Semanal</button>
+        <button class="btn-tab" data-view="day">Diária</button>
+      </div>
+
+      <select id="employeeSelect" title="Selecionar funcionário"></select>
+      <button class="btn ghost" id="todayBtn">Hoje</button>
+
+      <button class="btn adminOnly" id="syncAllBtn">📡 Sincronizar feriados</button>
+      <button class="btn adminOnly" id="openSettings">⚙️ Configurar APIs</button>
+      <button class="btn adminOnly" id="manageUsersBtn">👤 Usuários</button>
+
+      <span class="kbd" id="sessionBadge">—</span>
+      <button class="btn" id="logoutBtn">Sair</button>
+    </div>
+  </header>
+
+  <main>
+    <section class="calendar" aria-label="Calendário">
+      <div class="cal-header split">
+        <div class="split">
+          <span class="label">Data selecionada:</span>
+          <span id="selectedDateLabel" class="pill">—</span>
+        </div>
+        <div class="split">
+          <button class="btn adminOnly" id="toggleHolidayBtn">⛱️ Marcar/Desmarcar Feriado</button>
+          <button class="btn adminOnly" id="editScaleBtn">👥 Editar escala</button>
+          <button class="btn primary" id="swapBtn">🔄 Solicitar troca</button>
+        </div>
+      </div>
+      <div id="calendarBody"></div>
+    </section>
+
+    <div class="side">
+      <section class="panel">
+        <h3>Visão Equipe</h3>
+        <div class="split" style="margin-bottom:.6rem">
+          <div class="split">
+            <div class="label">Data base</div>
+            <input type="date" id="teamDate">
+          </div>
+          <div class="btn-group" style="margin-left:.4rem">
+            <button class="btn-tab active" data-team="day">Dia</button>
+            <button class="btn-tab" data-team="week">Semana</button>
+          </div>
+          <div class="right muted" id="teamMeta"></div>
+        </div>
+        <div style="overflow:auto;max-height:420px;border:1px solid #242a48;border-radius:12px">
+          <table id="teamTable">
+            <thead></thead>
+            <tbody></tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="panel" id="myRequestsPanel">
+        <h3>Minhas solicitações de troca</h3>
+        <div id="requestsList" class="list"></div>
+      </section>
+
+      <section class="panel adminOnly">
+        <h3>Painel do Admin — Aprovar trocas</h3>
+        <div id="adminRequestsList" class="list"></div>
+      </section>
+
+      <section class="panel">
+        <h3>Feriados</h3>
+        <div class="grid3 adminOnly">
+          <input type="date" id="holidayDate">
+          <button class="btn" id="addHolidayBtn">➕ Adicionar</button>
+          <button class="btn" id="resyncYearBtn">🔁 Re-sync ano visível</button>
+        </div>
+        <div id="holidayList" class="list" style="margin-top:.8rem"></div>
+      </section>
+    </div>
+  </main>
+
+  <!-- Modal -->
+  <div id="modal" style="display:none;position:fixed;inset:0;background:rgba(0,0,0,.5);align-items:center;justify-content:center;z-index:50;">
+    <div class="panel" style="width:min(680px,92vw);max-height:86vh;overflow:auto">
+      <div class="split">
+        <h3 id="modalTitle">Modal</h3>
+        <button class="btn" id="closeModal">✖</button>
+      </div>
+      <div id="modalContent"></div>
+    </div>
+  </div>
+
+  <!-- Settings bottom sheet -->
+  <div class="settings" id="settingsSheet">
+    <div class="sheet">
+      <div class="split" style="justify-content:space-between">
+        <h3>Configurações de Feriados (UF/Município & APIs)</h3>
+        <button class="btn" id="closeSettings">Fechar</button>
+      </div>
+      <div class="grid3">
+        <div>
+          <div class="label">UF (estado)</div>
+          <select id="ufSelect">
+            <option value="SP" selected>SP — São Paulo</option>
+            <option value="RJ">RJ — Rio de Janeiro</option>
+            <option value="MG">MG — Minas Gerais</option>
+            <option value="RS">RS — Rio Grande do Sul</option>
+            <option value="PR">PR — Paraná</option>
+          </select>
+        </div>
+        <div>
+          <div class="label">Município (IBGE)</div>
+          <input id="ibgeCity" type="text" value="3550308" placeholder="ex.: 3550308 (São Paulo)"/>
+        </div>
+        <div>
+          <div class="label">Ano alvo</div>
+          <input id="settingsYear" type="number" min="2000" max="2100" />
+        </div>
+      </div>
+
+      <div class="grid2" style="margin-top:.8rem">
+        <div>
+          <div class="label">Calendarific API Key (estado/UF)</div>
+          <input id="calendarificKey" type="text" placeholder="opcional — region=UF"/>
+        </div>
+        <div>
+          <div class="label">Invertexto Token (municipal)</div>
+          <input id="invertextoToken" type="text" placeholder="opcional — city=IBGE"/>
+        </div>
+      </div>
+
+      <div class="split" style="justify-content:flex-end;margin-top:1rem">
+        <button class="btn" id="saveSettings">Salvar</button>
+        <button class="btn primary" id="testSync">Testar sync agora</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Login -->
+  <div id="loginOverlay">
+    <div class="loginCard">
+      <h3 style="margin-top:0">Entrar</h3>
+      <div class="grid2">
+        <div>
+          <div class="label">Perfil</div>
+          <select id="loginRole">
+            <option value="admin">Admin</option>
+            <option value="func" selected>Funcionário</option>
+          </select>
+        </div>
+        <div id="loginEmployeeWrap">
+          <div class="label">Funcionário</div>
+          <select id="loginEmployee"></select>
+        </div>
+      </div>
+      <div class="split" style="justify-content:flex-end;margin-top:1rem">
+        <button class="btn primary" id="loginBtn">Entrar</button>
+      </div>
+      <div class="muted" style="font-size:.9rem;margin-top:.4rem">
+        Funcionário vê a escala e solicita trocas. Admin gerencia tudo.
+      </div>
+    </div>
+  </div>
+
+  <script type="module" src="./js/main.js"></script>
+</body>
+</html>

--- a/src/js/auth.js
+++ b/src/js/auth.js
@@ -1,0 +1,61 @@
+import { DATA, saveData } from './storage.js';
+import { SESSION, saveSession, clearSession, isAdmin } from './session.js';
+import { state } from './state.js';
+import { renderCalendar } from './calendar.js';
+
+const employeeSelect = document.getElementById('employeeSelect');
+const loginOverlay = document.getElementById('loginOverlay');
+const loginRole = document.getElementById('loginRole');
+const loginEmployeeWrap = document.getElementById('loginEmployeeWrap');
+const loginEmployee = document.getElementById('loginEmployee');
+const sessionBadge = document.getElementById('sessionBadge');
+
+export function refreshEmployeeSelect(){
+  employeeSelect.innerHTML = DATA.employees.map(n=>`<option value="${n}">${n}</option>`).join('');
+  if(!DATA.employees.includes(state.currentEmployee)) state.currentEmployee = DATA.employees[0] || '';
+  employeeSelect.value = state.currentEmployee;
+}
+export function fillLoginEmployees(){ loginEmployee.innerHTML = DATA.employees.map(e=>`<option>${e}</option>`).join(''); }
+
+export function updateRoleUI(){
+  if(!SESSION){ sessionBadge.textContent='—'; }
+  else{ sessionBadge.textContent = (isAdmin()?'Admin':'Funcionário') + ' • ' + (isAdmin()?'—':SESSION.name); }
+  document.querySelectorAll('.adminOnly').forEach(el=>{ el.style.display = isAdmin()? '' : 'none'; });
+  if(isAdmin()){
+    employeeSelect.disabled = false;
+    employeeSelect.parentElement.style.display = '';
+  }else{
+    state.currentEmployee = SESSION?.name || state.currentEmployee;
+    refreshEmployeeSelect();
+    employeeSelect.disabled = true;
+  }
+}
+
+export function showLogin(){
+  fillLoginEmployees();
+  loginOverlay.style.display='flex';
+  loginRole.value='func';
+  loginEmployeeWrap.style.display='block';
+}
+export function afterLogin(){
+  loginOverlay.style.display='none';
+  state.currentEmployee = isAdmin()? (DATA.employees[0]||'—') : SESSION.name;
+  refreshEmployeeSelect();
+  updateRoleUI();
+  renderCalendar();
+}
+
+export function initAuth(){
+  refreshEmployeeSelect();
+  fillLoginEmployees();
+  loginRole.onchange = ()=>{ loginEmployeeWrap.style.display = loginRole.value==='func' ? 'block' : 'none'; };
+  document.getElementById('loginBtn').onclick = ()=>{
+    const role = loginRole.value;
+    const name = role==='func' ? loginEmployee.value : 'Admin';
+    if(role==='func' && !DATA.employees.includes(name)) return alert('Funcionário inválido.');
+    SESSION.role = role; SESSION.name = name; saveSession();
+    afterLogin();
+  };
+  document.getElementById('logoutBtn').onclick = ()=>{ clearSession(); showLogin(); };
+  employeeSelect.onchange = ()=>{ state.currentEmployee = employeeSelect.value; renderCalendar(); };
+}

--- a/src/js/calendar.js
+++ b/src/js/calendar.js
@@ -1,0 +1,89 @@
+import { fmt, parse, startOfWeek, addDays, monthLabel } from './utils.js';
+import { DATA, ensureDay, getDayInfo } from './storage.js';
+import { state } from './state.js';
+
+export const calendarBody = document.getElementById('calendarBody');
+const selectedDateLabel = document.getElementById('selectedDateLabel');
+const currentLabel = document.getElementById('currentLabel');
+
+export function cellBadges(d){
+  const info = getDayInfo(d);
+  const out = [];
+  if(info.holiday){
+    const tag = info.scope==='MUN' ? 'SP-Capital' : info.scope==='UF' ? 'SP' : 'BR';
+    out.push(`<span class="badge holiday">⛱️ ${info.holidayName||'Feriado'} <span class="muted" style="font-size:.7rem">(${tag})</span></span>`);
+  }
+  const status = info.assignments[state.currentEmployee];
+  if(status) out.push(`<span class="badge ${status==='folga'?'off':'work'}">${status[0].toUpperCase()+status.slice(1)}</span>`);
+  return out.join('');
+}
+
+function renderMonth(){
+  const y=state.currentDate.getFullYear(), m=state.currentDate.getMonth();
+  const first=new Date(y,m,1), start=startOfWeek(first);
+  const days=42;
+  currentLabel.textContent = monthLabel(state.currentDate);
+  let html = `<div class="cal-weekdays">${['Seg','Ter','Qua','Qui','Sex','Sáb','Dom'].map(d=>`<div>${d}</div>`).join('')}</div><div class="cal-grid">`;
+  for(let i=0;i<days;i++){
+    const d = addDays(start,i);
+    const isToday = fmt(d)===fmt(new Date());
+    html += `<div class="cal-cell ${isToday?'today':''}" data-date="${fmt(d)}"><div class="date">${d.getDate()}</div><div class="badges">${cellBadges(d)}</div></div>`;
+  }
+  html += `</div>`;
+  calendarBody.innerHTML = html;
+}
+function renderWeek(){
+  const start = startOfWeek(state.currentDate);
+  currentLabel.textContent = `Semana de ${start.toLocaleDateString('pt-BR')}`;
+  let html = `<div class="cal-weekdays">${['Seg','Ter','Qua','Qui','Sex','Sáb','Dom'].map((d,i)=>`<div>${d} • ${addDays(start,i).toLocaleDateString('pt-BR',{day:'2-digit',month:'2-digit'})}</div>`).join('')}</div><div class="cal-grid">`;
+  for(let i=0;i<7;i++){
+    const d = addDays(start,i);
+    const isToday = fmt(d)===fmt(new Date());
+    html += `<div class="cal-cell ${isToday?'today':''}" data-date="${fmt(d)}"><div class="date">${d.getDate()}</div><div class="badges">${cellBadges(d)}</div></div>`;
+  }
+  html += `</div>`;
+  calendarBody.innerHTML = html;
+}
+function renderDay(){
+  const info = getDayInfo(state.currentDate);
+  currentLabel.textContent = state.currentDate.toLocaleDateString('pt-BR', {weekday:'long', day:'2-digit', month:'long', year:'numeric'});
+  const isToday = fmt(state.currentDate)===fmt(new Date());
+  calendarBody.innerHTML = `
+    <div class="cal-weekdays"><div style="grid-column:1/-1;text-align:left;padding:.8rem 1rem">${isToday?'<span class="pill ok">Hoje</span>':''}</div></div>
+    <div class="cal-grid" style="grid-template-columns:1fr;">
+      <div class="cal-cell today" data-date="${fmt(state.currentDate)}">
+        <div class="split" style="justify-content:space-between">
+          <div class="date" style="font-size:1.2rem">${state.currentDate.toLocaleDateString('pt-BR')}</div>
+          <div class="badges">${cellBadges(state.currentDate)}</div>
+        </div>
+        <div style="margin-top:.8rem">
+          <div class="label">Escala do dia</div>
+          <div class="list">
+            ${DATA.employees.map(e=>{
+              const st = info.assignments[e] || 'trabalho';
+              const cls = st==='folga'?'off':'work';
+              return `<div class="row"><div>${e}</div><div class="badge ${cls}">${st}</div></div>`
+            }).join('')}
+          </div>
+        </div>
+      </div>
+    </div>`;
+}
+
+export function renderCalendar(){
+  selectedDateLabel.textContent = state.selectedDate.toLocaleDateString('pt-BR');
+  if(state.currentView==='month') renderMonth();
+  else if(state.currentView==='week') renderWeek();
+  else renderDay();
+  bindCellClicks();
+}
+
+function bindCellClicks(){
+  document.querySelectorAll('.cal-cell').forEach(el=>{
+    el.onclick = ()=>{
+      state.selectedDate = parse(el.dataset.date);
+      state.currentDate = new Date(state.selectedDate);
+      renderCalendar();
+    };
+  });
+}

--- a/src/js/holidays.js
+++ b/src/js/holidays.js
@@ -1,0 +1,109 @@
+import { DATA, saveData, ensureDay } from './storage.js';
+import { parse } from './utils.js';
+import { isAdmin } from './session.js';
+import { fmt, dedupeByDate, toast } from './utils.js';
+
+const holidayList = document.getElementById('holidayList');
+
+export function markHoliday(dateStr, name="Feriado", scope='BR'){
+  ensureDay(dateStr);
+  DATA.schedules[dateStr].holiday = true;
+  DATA.schedules[dateStr].holidayName = name;
+  DATA.schedules[dateStr].scope = scope;
+}
+export function unmarkHoliday(dateStr){
+  ensureDay(dateStr);
+  DATA.schedules[dateStr].holiday = false;
+  delete DATA.schedules[dateStr].holidayName;
+  delete DATA.schedules[dateStr].scope;
+}
+
+export function refreshHolidaysPanel(){
+  const entries = Object.entries(DATA.schedules).filter(([,v])=>v.holiday).sort((a,b)=>a[0].localeCompare(b[0]));
+  holidayList.innerHTML = entries.length? entries.map(([k,v])=>{
+    const d = parse(k);
+    const tag = v.scope==='MUN' ? 'SP-Capital' : v.scope==='UF' ? 'SP' : 'BR';
+    return `<div class="row">
+      <div>
+        <div>${d.toLocaleDateString('pt-BR')}</div>
+        <div class="muted" style="font-size:.85rem">${v.holidayName||'Feriado'} (${tag})</div>
+      </div>
+      ${isAdmin()?`<button class="btn" data-unmark="${k}">Remover</button>`:''}
+    </div>`;
+  }).join('') : `<div class="empty">Nenhum feriado cadastrado.</div>`;
+  holidayList.querySelectorAll('[data-unmark]').forEach(b=>{
+    b.onclick = ()=>{ unmarkHoliday(b.dataset.unmark); saveData(); refreshHolidaysPanel(); };
+  });
+}
+
+// API helpers
+export async function fetchBRHolidays(year){
+  try{
+    const r = await fetch(`https://brasilapi.com.br/api/feriados/v1/${year}`, {cache:'no-store'});
+    if(r.ok){ const list = await r.json(); return list.map(x=>({ date:x.date, name:x.name })); }
+  }catch(e){}
+  try{
+    const r2 = await fetch(`https://date.nager.at/api/v3/PublicHolidays/${year}/BR`, {cache:'no-store'});
+    if(r2.ok){ const list2 = await r2.json(); return list2.map(x=>({ date:x.date, name:x.localName || x.name || 'Feriado' })); }
+  }catch(e){}
+  throw new Error('Falha ao obter feriados nacionais.');
+}
+export async function fetchUFHolidays_Calendarific(year, uf, apiKey){
+  if(!apiKey) return [];
+  const url = `https://calendarific.com/api/v2/holidays?api_key=${encodeURIComponent(apiKey)}&country=BR&year=${year}&region=${encodeURIComponent(uf)}`;
+  const r = await fetch(url, {cache:'no-store'});
+  if(!r.ok) throw new Error('Calendarific não respondeu.');
+  const data = await r.json();
+  const items = (data?.response?.holidays)||[];
+  const out = [];
+  items.forEach(h=>{
+    try{
+      const date = h.date?.iso?.slice(0,10);
+      const name = h.name || h.local_name || 'Feriado';
+      const types = h.type || [];
+      if(date && (types.includes('National holiday') || types.includes('Local holiday') || types.includes('State holiday') || types.includes('Public holiday'))){
+        out.push({date, name});
+      }
+    }catch{}
+  });
+  return dedupeByDate(out);
+}
+export async function fetchCityHolidays_Invertexto(year, uf, ibgeCity, token){
+  if(!token) return [];
+  const url = `https://api.invertexto.com/v1/holidays/${year}?token=${encodeURIComponent(token)}&state=${encodeURIComponent(uf)}&city=${encodeURIComponent(ibgeCity)}`;
+  const r = await fetch(url, {cache:'no-store'});
+  if(!r.ok) throw new Error('Invertexto não respondeu.');
+  const list = await r.json();
+  const out = (Array.isArray(list)?list:[]).map(x=>({ date:x.date, name:x.name || 'Feriado municipal'}));
+  return dedupeByDate(out);
+}
+
+export async function syncBR(year, {force=false}={}){
+  if(!force && DATA.holidaySyncedYears.includes(year)) return 0;
+  const list = await fetchBRHolidays(year);
+  list.forEach(h=>markHoliday(h.date, h.name, 'BR'));
+  if(!DATA.holidaySyncedYears.includes(year)) DATA.holidaySyncedYears.push(year);
+  saveData();
+  return list.length;
+}
+export async function syncUF(year, uf, key, {force=false}={}){
+  if(!force && DATA.prefs.syncedUF[year]) return 0;
+  const list = await fetchUFHolidays_Calendarific(year, uf, key).catch(()=>[]);
+  list.forEach(h=>markHoliday(h.date, h.name, 'UF'));
+  DATA.prefs.syncedUF[year] = true; saveData(); return list.length;
+}
+export async function syncCity(year, uf, ibgeCity, token, {force=false}={}){
+  if(!force && DATA.prefs.syncedCity[year]) return 0;
+  const list = await fetchCityHolidays_Invertexto(year, uf, ibgeCity, token).catch(()=>[]);
+  list.forEach(h=>markHoliday(h.date, h.name, 'MUN'));
+  DATA.prefs.syncedCity[year] = true; saveData(); return list.length;
+}
+export async function syncAll(year, {force=false}={}){
+  const {uf, ibgeCity, calendarificKey, invertextoToken} = DATA.prefs;
+  let total=0;
+  try{ total += await syncBR(year,{force}); }catch{ toast('Falha nos feriados nacionais'); }
+  try{ total += await syncUF(year, uf, calendarificKey,{force}); }catch{}
+  try{ total += await syncCity(year, uf, ibgeCity, invertextoToken,{force}); }catch{}
+  toast(`Sincronizado ${year}: ${total} feriados (BR/UF/MUN)`);
+  return total;
+}

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1,0 +1,132 @@
+import { state } from './state.js';
+import { renderCalendar, calendarBody } from './calendar.js';
+import { markHoliday, unmarkHoliday, refreshHolidaysPanel, syncAll, syncBR } from './holidays.js';
+import { openModal, modal } from './modal.js';
+import { ensureDay, DATA, saveData } from './storage.js';
+import { isAdmin, SESSION } from './session.js';
+import { refreshRequests, refreshAdminRequests } from './swap.js';
+import { initTeamView, renderTeamView } from './teamView.js';
+import { initSettings } from './settings.js';
+import { initAuth, showLogin, afterLogin, updateRoleUI, refreshEmployeeSelect } from './auth.js';
+import { openUserManager } from './userManagement.js';
+import { fmt } from './utils.js';
+
+// navigation buttons
+document.getElementById('prevBtn').onclick = ()=>{
+  if(state.currentView==='month'){ state.currentDate.setMonth(state.currentDate.getMonth()-1); }
+  else if(state.currentView==='week'){ state.currentDate = new Date(state.currentDate.getTime()-7*86400000); }
+  else { state.currentDate = new Date(state.currentDate.getTime()-86400000); }
+  renderAll();
+};
+document.getElementById('nextBtn').onclick = ()=>{
+  if(state.currentView==='month'){ state.currentDate.setMonth(state.currentDate.getMonth()+1); }
+  else if(state.currentView==='week'){ state.currentDate = new Date(state.currentDate.getTime()+7*86400000); }
+  else { state.currentDate = new Date(state.currentDate.getTime()+86400000); }
+  renderAll();
+};
+document.getElementById('todayBtn').onclick = ()=>{ state.currentDate=new Date(); state.selectedDate=new Date(); renderAll(); };
+document.querySelectorAll('.btn-tab[data-view]').forEach(b=>{
+  b.onclick = ()=>{ document.querySelectorAll('.btn-tab[data-view]').forEach(x=>x.classList.remove('active')); b.classList.add('active'); state.currentView=b.dataset.view; renderAll(); };
+});
+
+// holiday toggle
+const toggleHolidayBtn = document.getElementById('toggleHolidayBtn');
+toggleHolidayBtn.onclick = ()=>{
+  if(!isAdmin()) return;
+  const k = fmt(state.selectedDate);
+  ensureDay(k);
+  DATA.schedules[k].holiday ? unmarkHoliday(k) : markHoliday(k);
+  saveData(); renderAll();
+};
+// add holiday
+const addHolidayBtn = document.getElementById('addHolidayBtn');
+addHolidayBtn.onclick = ()=>{
+  if(!isAdmin()) return;
+  const input=document.getElementById('holidayDate');
+  if(!input.value) return alert('Selecione uma data.');
+  markHoliday(input.value, 'Feriado manual', 'BR');
+  saveData(); renderAll();
+};
+
+// edit scale
+const editScaleBtn = document.getElementById('editScaleBtn');
+editScaleBtn.onclick = ()=>{
+  if(!isAdmin()) return;
+  const k = fmt(state.selectedDate);
+  ensureDay(k);
+  const info = DATA.schedules[k];
+  const list = DATA.employees.map(e=>{
+    const st = info.assignments[e] || 'trabalho';
+    return `<div class="row">
+      <div>${e}</div>
+      <div class="split">
+        <label class="split" style="gap:.35rem"><input type="radio" name="st_${e}" value="trabalho" ${st==='trabalho'?'checked':''}/> Trabalho</label>
+        <label class="split" style="gap:.35rem"><input type="radio" name="st_${e}" value="folga" ${st==='folga'?'checked':''}/> Folga</label>
+      </div>
+    </div>`;
+  }).join('');
+  openModal(`Editar escala — ${state.selectedDate.toLocaleDateString('pt-BR')}`, `
+    <div class="split" style="margin-bottom:.6rem">
+      <div><span class="label">Este dia é</span> <span class="pill ${info.holiday?'warn':''}">${info.holiday?(info.holidayName||'Feriado'):'Dia normal'}</span></div>
+      <button class="btn" id="toggleHolidayInside">⛱️ Alternar feriado</button>
+    </div>
+    <div class="list">${list}</div>
+    <div class="split" style="justify-content:end;margin-top:1rem">
+      <button class="btn primary" id="saveScale">Salvar</button>
+    </div>
+  `);
+  document.getElementById('toggleHolidayInside').onclick = ()=>{
+    if(info.holiday){ info.holiday=false; delete info.holidayName; delete info.scope; }
+    else { info.holiday=true; if(!info.holidayName) info.holidayName='Feriado'; if(!info.scope) info.scope='BR'; }
+    saveData(); const pill=document.querySelector('#modal .pill'); pill.textContent=info.holiday?(info.holidayName||'Feriado'):'Dia normal'; pill.classList.toggle('warn', info.holiday);
+  };
+  document.getElementById('saveScale').onclick = ()=>{
+    DATA.employees.forEach(e=>{
+      const val = document.querySelector(`input[name="st_${CSS.escape(e)}"]:checked`)?.value || 'trabalho';
+      info.assignments[e] = val;
+    });
+    saveData(); modal.style.display='none'; renderAll();
+  };
+};
+
+// manage users
+const manageUsersBtn = document.getElementById('manageUsersBtn');
+manageUsersBtn.onclick = ()=>{ if(!isAdmin()) return; openUserManager(refreshAllUI); };
+
+// sync buttons
+document.getElementById('syncAllBtn').onclick = ()=>{ if(!isAdmin()) return; syncAll(state.currentDate.getFullYear()); };
+document.getElementById('resyncYearBtn').onclick = ()=>{ if(!isAdmin()) return; syncAll(state.currentDate.getFullYear(), {force:true}); };
+
+function renderAll(){
+  renderCalendar();
+  refreshHolidaysPanel();
+  refreshRequests();
+  refreshAdminRequests();
+  renderTeamView();
+}
+
+function refreshAllUI(){
+  refreshEmployeeSelect();
+  updateRoleUI();
+  renderAll();
+}
+
+// initialization
+initAuth();
+initSettings();
+initTeamView();
+refreshHolidaysPanel();
+refreshRequests();
+refreshAdminRequests();
+renderTeamView();
+
+if(!SESSION){ showLogin(); } else { afterLogin(); }
+
+syncBR(new Date().getFullYear()).catch(()=>{});
+
+// accessibility
+document.addEventListener('keydown', (e)=>{
+  if(e.key==='Escape'){ modal.style.display='none'; document.getElementById('settingsSheet').style.display='none'; }
+  if(e.key==='ArrowLeft'){ document.getElementById('prevBtn').click(); }
+  if(e.key==='ArrowRight'){ document.getElementById('nextBtn').click(); }
+});

--- a/src/js/modal.js
+++ b/src/js/modal.js
@@ -1,0 +1,5 @@
+export const modal = document.getElementById('modal');
+const modalTitle = document.getElementById('modalTitle');
+export const modalContent = document.getElementById('modalContent');
+document.getElementById('closeModal').onclick = ()=> modal.style.display='none';
+export function openModal(title, html){ modalTitle.textContent=title; modalContent.innerHTML=html; modal.style.display='flex'; }

--- a/src/js/session.js
+++ b/src/js/session.js
@@ -1,0 +1,5 @@
+export function loadSession(){ try{ return JSON.parse(localStorage.getItem('session_v1')) || null; }catch{ return null; } }
+export function saveSession(){ localStorage.setItem('session_v1', JSON.stringify(SESSION)); }
+export function clearSession(){ localStorage.removeItem('session_v1'); SESSION=null; }
+export let SESSION = loadSession();
+export const isAdmin = ()=> SESSION?.role==='admin';

--- a/src/js/settings.js
+++ b/src/js/settings.js
@@ -1,0 +1,37 @@
+import { DATA, saveData } from './storage.js';
+import { syncAll } from './holidays.js';
+import { toast } from './utils.js';
+import { state } from './state.js';
+
+const sheet = document.getElementById('settingsSheet');
+const ufSelect = document.getElementById('ufSelect');
+const ibgeCity = document.getElementById('ibgeCity');
+const calendarificKey = document.getElementById('calendarificKey');
+const invertextoToken = document.getElementById('invertextoToken');
+const settingsYear = document.getElementById('settingsYear');
+
+export function openSettingsSheet(){
+  ufSelect.value = DATA.prefs.uf || 'SP';
+  ibgeCity.value = DATA.prefs.ibgeCity || '3550308';
+  calendarificKey.value = DATA.prefs.calendarificKey || '';
+  invertextoToken.value = DATA.prefs.invertextoToken || '';
+  settingsYear.value = state.currentDate.getFullYear();
+  sheet.style.display='flex';
+}
+export function closeSettingsSheet(){ sheet.style.display='none'; }
+
+export function initSettings(){
+  document.getElementById('openSettings').onclick = ()=> openSettingsSheet();
+  document.getElementById('closeSettings').onclick = closeSettingsSheet;
+  document.getElementById('saveSettings').onclick = ()=>{
+    DATA.prefs.uf = ufSelect.value.trim() || 'SP';
+    DATA.prefs.ibgeCity = ibgeCity.value.trim() || '3550308';
+    DATA.prefs.calendarificKey = calendarificKey.value.trim();
+    DATA.prefs.invertextoToken = invertextoToken.value.trim();
+    saveData(); sheet.style.display='none'; toast('Configurações salvas');
+  };
+  document.getElementById('testSync').onclick = async ()=>{
+    const y=parseInt(settingsYear.value||state.currentDate.getFullYear(),10);
+    await syncAll(y,{force:true});
+  };
+}

--- a/src/js/state.js
+++ b/src/js/state.js
@@ -1,0 +1,10 @@
+import { DATA } from './storage.js';
+
+export const state = {
+  currentView: 'month',
+  currentDate: new Date(),
+  selectedDate: new Date(),
+  currentEmployee: DATA.employees[0] || '—',
+  teamMode: 'day',
+  teamDate: new Date()
+};

--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -1,0 +1,41 @@
+import { fmt } from './utils.js';
+
+export const defaultData = {
+  employees: ["Ana","Bruno","Carla","Diego"],
+  schedules: {},
+  swapRequests: [],
+  holidaySyncedYears: [],
+  prefs: { uf:'SP', ibgeCity:'3550308', calendarificKey:'', invertextoToken:'', syncedUF:{}, syncedCity:{} },
+};
+
+export function loadData(){
+  const raw = localStorage.getItem('escala_data_roles_users_openreq_v1');
+  if(!raw){
+    localStorage.setItem('escala_data_roles_users_openreq_v1', JSON.stringify(defaultData));
+    return structuredClone(defaultData);
+  }
+  try{
+    const d = JSON.parse(raw);
+    d.prefs ||= structuredClone(defaultData.prefs);
+    d.prefs.syncedUF ||= {};
+    d.prefs.syncedCity ||= {};
+    d.employees ||= ["Ana","Bruno","Carla","Diego"];
+    d.swapRequests ||= [];
+    return d;
+  }catch{
+    localStorage.setItem('escala_data_roles_users_openreq_v1', JSON.stringify(defaultData));
+    return structuredClone(defaultData);
+  }
+}
+export function saveData(){ localStorage.setItem('escala_data_roles_users_openreq_v1', JSON.stringify(DATA)); }
+export let DATA = loadData();
+
+export function ensureDay(dateStr){
+  if(!DATA.schedules[dateStr]){
+    DATA.schedules[dateStr] = { holiday:false, assignments:{} };
+    DATA.employees.forEach((e,i)=>{
+      DATA.schedules[dateStr].assignments[e] = (i%2===0)?'trabalho':'folga';
+    });
+  }
+}
+export function getDayInfo(date){ const k=fmt(date); ensureDay(k); return DATA.schedules[k]; }

--- a/src/js/swap.js
+++ b/src/js/swap.js
@@ -1,0 +1,236 @@
+import { DATA, saveData, ensureDay } from './storage.js';
+import { fmt, parse } from './utils.js';
+import { state } from './state.js';
+import { openModal, modal, modalContent } from './modal.js';
+import { SESSION, isAdmin, saveSession } from './session.js';
+import { renderCalendar, cellBadges } from './calendar.js';
+import { toast } from './utils.js';
+
+const requestsList = document.getElementById('requestsList');
+const adminRequestsList = document.getElementById('adminRequestsList');
+
+export function refreshRequests(){
+  if(!SESSION) return;
+  const mine = DATA.swapRequests.filter(r=>r.requester===SESSION.name);
+  requestsList.innerHTML = mine.length? mine.slice().reverse().map(r=>{
+    let status = r.status;
+    if(r.open && r.status==='pendente') status = 'aberta';
+    const statusCls = status==='aprovada'?'ok': status==='recusada'?'warn':'wait';
+    const details = r.open
+      ? `Aberta • sua data <strong>${r.fromDate}</strong>${r.toDate?` • deseja <strong>${r.toDate}</strong>`:''}`
+      : `<strong>${r.fromDate}</strong> → <strong>${r.toDate}</strong> com <strong>${r.toEmployee}</strong>`;
+    return `<div class="row">
+      <div style="max-width:60%">
+        <div>${details}</div>
+        <div class="muted" style="font-size:.85rem">${r.reason||'Sem motivo informado'}</div>
+      </div>
+      <span class="pill ${statusCls}">${status}</span>
+    </div>`;
+  }).join('') : `<div class="empty">Você ainda não fez solicitações.</div>`;
+}
+
+export function refreshAdminRequests(){
+  if(!isAdmin()){ adminRequestsList.innerHTML=''; return; }
+  const all = DATA.swapRequests.slice().reverse();
+  adminRequestsList.innerHTML = all.length? all.map(r=>{
+    const baseInfo = r.open
+      ? `<strong>${r.requester}</strong> abriu troca da sua data <strong>${r.fromDate}</strong>${r.toDate?` (deseja ${r.toDate})`:''}`
+      : `<strong>${r.requester}</strong> troca <strong>${r.fromDate}</strong> com <strong>${r.toEmployee}</strong> em <strong>${r.toDate}</strong>`;
+    const status = r.open && r.status==='pendente' ? 'aberta' : r.status;
+    const statusCls = status==='aprovada'?'ok': status==='recusada'?'warn':'wait';
+    const actions = r.status==='pendente'
+      ? (r.open
+          ? `<button class="btn" data-link="${r.id}">Definir par</button>
+             <button class="btn" data-reject="${r.id}">Recusar</button>`
+          : `<button class="btn" data-approve="${r.id}">Aprovar</button>
+             <button class="btn" data-reject="${r.id}">Recusar</button>`)
+      : `<span class="pill ${statusCls}">${status}</span>`;
+    return `<div class="row">
+      <div style="max-width:60%">
+        <div>${baseInfo}</div>
+        <div class="muted" style="font-size:.85rem">${r.reason||'—'}</div>
+      </div>
+      <div class="split">${actions}</div>
+    </div>`;
+  }).join('') : `<div class="empty">Sem solicitações.</div>`;
+
+  adminRequestsList.querySelectorAll('[data-approve]').forEach(b=>{
+    b.onclick = ()=>{
+      const id = b.dataset.approve;
+      const r = DATA.swapRequests.find(x=>x.id===id);
+      if(!r || r.open) return;
+      if(!validateSwap(r)) return;
+      applySwap(r);
+      r.status = 'aprovada';
+      saveData(); renderCalendar();
+      alert('Troca aprovada e aplicada.');
+    };
+  });
+  adminRequestsList.querySelectorAll('[data-reject]').forEach(b=>{
+    b.onclick = ()=>{
+      const id = b.dataset.reject;
+      const r = DATA.swapRequests.find(x=>x.id===id);
+      if(!r) return;
+      r.status = 'recusada';
+      saveData(); renderCalendar();
+    };
+  });
+  adminRequestsList.querySelectorAll('[data-link]').forEach(b=>{
+    b.onclick = ()=>{
+      const id = b.dataset.link;
+      const r = DATA.swapRequests.find(x=>x.id===id);
+      if(!r) return;
+      openLinkModal(r);
+    };
+  });
+}
+
+export function validateSwap(r){
+  if(!r.requester || !r.toEmployee || !r.fromDate || !r.toDate) { alert('Dados incompletos da troca.'); return false; }
+  if(r.requester===r.toEmployee){ alert('Funcionários devem ser diferentes.'); return false; }
+  if(r.fromDate===r.toDate){ alert('Datas da troca não podem ser iguais.'); return false; }
+  return true;
+}
+export function applySwap(r){
+  const {requester, toEmployee, fromDate, toDate} = r;
+  ensureDay(fromDate); ensureDay(toDate);
+  const a1 = DATA.schedules[fromDate].assignments;
+  [a1[requester], a1[toEmployee]] = [a1[toEmployee], a1[requester]];
+  const a2 = DATA.schedules[toDate].assignments;
+  [a2[requester], a2[toEmployee]] = [a2[toEmployee], a2[requester]];
+}
+
+export function openLinkModal(r){
+  const empOptions = DATA.employees.filter(e=>e!==r.requester).map(e=>`<option>${e}</option>`).join('');
+  openModal('Definir par para troca aberta', `
+    <div class="grid2">
+      <div>
+        <div class="label">Solicitante</div>
+        <input type="text" value="${r.requester}" disabled/>
+      </div>
+      <div>
+        <div class="label">Data do solicitante</div>
+        <input type="date" id="link_from" value="${r.fromDate}" />
+      </div>
+      <div>
+        <div class="label">Funcionário parceiro</div>
+        <select id="link_emp">${empOptions}</select>
+      </div>
+      <div>
+        <div class="label">Data do parceiro</div>
+        <input type="date" id="link_to" value="${r.toDate||r.fromDate}" />
+      </div>
+    </div>
+    <div class="split" style="justify-content:flex-end;margin-top:.8rem">
+      <button class="btn primary" id="linkSave">Vincular</button>
+    </div>
+  `);
+  document.getElementById('linkSave').onclick = ()=>{
+    const toEmployee = document.getElementById('link_emp').value;
+    const fromDate = document.getElementById('link_from').value;
+    const toDate = document.getElementById('link_to').value;
+    if(!toEmployee || !fromDate || !toDate) return alert('Preencha todos os campos.');
+    r.toEmployee = toEmployee;
+    r.fromDate = fromDate;
+    r.toDate = toDate;
+    r.open = false;
+    saveData(); modal.style.display='none'; renderCalendar();
+  };
+}
+
+// Swap button handler
+const swapBtn = document.getElementById('swapBtn');
+swapBtn.onclick = ()=>{
+  const k = fmt(state.selectedDate);
+  ensureDay(k);
+  const info = DATA.schedules[k];
+  const my = isAdmin()? state.currentEmployee : (SESSION?.name || state.currentEmployee);
+  const myStatus = info.assignments[my] || 'trabalho';
+  openModal('Solicitar troca de folga', `
+    <div class="grid2">
+      <div>
+        <div class="label">Você (solicitante)</div>
+        <input type="text" value="${my}" disabled/>
+      </div>
+      <div>
+        <div class="label">Sua data</div>
+        <input type="date" id="fromDate" value="${k}"/>
+      </div>
+    </div>
+
+    <div class="row" style="margin-top:.6rem">
+      <label class="split" style="gap:.5rem"><input type="checkbox" id="openSwap"/> Deixar em aberto (sem escolher funcionário agora)</label>
+    </div>
+
+    <div id="directFields" class="grid2" style="margin-top:.6rem">
+      <div>
+        <div class="label">Com quem</div>
+        <select id="toEmployee">${DATA.employees.filter(e=>e!==my).map(e=>`<option>${e}</option>`).join('')}</select>
+      </div>
+      <div>
+        <div class="label">Data desejada</div>
+        <input type="date" id="toDate" value="${k}"/>
+      </div>
+    </div>
+
+    <div id="openHint" class="muted" style="display:none;margin-top:.4rem;font-size:.9rem">
+      Você está criando uma solicitação <b>aberta</b>. O admin definirá o funcionário e a data de troca depois. Você pode indicar abaixo uma <i>data desejada</i> (opcional).
+    </div>
+    <div id="openDesired" style="display:none" class="grid2">
+      <div>
+        <div class="label">Data desejada (opcional)</div>
+        <input type="date" id="openDesiredDate" value="${k}"/>
+      </div>
+    </div>
+
+    <div style="margin-top:.6rem">
+      <div class="label">Motivo (opcional)</div>
+      <textarea id="reason" rows="3" style="width:100%" placeholder="Ex.: compromisso familiar, médico, etc."></textarea>
+    </div>
+
+    <div class="split" style="margin-top:.8rem;align-items:center">
+      <div class="muted" style="font-size:.9rem">Status em ${state.selectedDate.toLocaleDateString('pt-BR')}: <span class="pill ${myStatus==='folga'?'ok':'warn'}">${myStatus}</span></div>
+      <button class="btn primary right" id="sendSwap">Enviar solicitação</button>
+    </div>
+  `);
+
+  const openSwap = document.getElementById('openSwap');
+  const directFields = document.getElementById('directFields');
+  const openHint = document.getElementById('openHint');
+  const openDesired = document.getElementById('openDesired');
+  const desiredInput = document.getElementById('openDesiredDate');
+
+  openSwap.onchange = ()=>{
+    const open = openSwap.checked;
+    directFields.style.display = open ? 'none' : 'grid';
+    openHint.style.display = open ? 'block' : 'none';
+    openDesired.style.display = open ? 'grid' : 'none';
+  };
+
+  document.getElementById('sendSwap').onclick = ()=>{
+    const fromDate = document.getElementById('fromDate').value;
+    const reason = document.getElementById('reason').value.trim();
+    const id = 'R'+Math.random().toString(36).slice(2,8);
+    if(!fromDate) return alert('Informe sua data.');
+
+    if(openSwap.checked){
+      const desired = desiredInput.value || null;
+      DATA.swapRequests.push({
+        id, requester: my, fromDate, toEmployee: null, toDate: desired, reason, status: 'pendente', open: true
+      });
+      saveData(); modal.style.display='none'; refreshRequests(); refreshAdminRequests();
+      alert('Solicitação aberta registrada (sem escolher funcionário).');
+    }else{
+      const toEmployee = document.getElementById('toEmployee').value;
+      const toDate = document.getElementById('toDate').value;
+      if(!toEmployee || !toDate) return alert('Selecione o funcionário e a data desejada.');
+      if(my===toEmployee) return alert('Escolha um colega diferente de você.');
+      if(fromDate===toDate) return alert('As datas não podem ser iguais.');
+      DATA.swapRequests.push({
+        id, requester: my, fromDate, toEmployee, toDate, reason, status:'pendente', open:false
+      });
+      saveData(); modal.style.display='none'; refreshRequests(); refreshAdminRequests();
+      alert('Solicitação registrada como "pendente".');
+    }
+  };
+};

--- a/src/js/teamView.js
+++ b/src/js/teamView.js
@@ -1,0 +1,56 @@
+import { fmt, parse, startOfWeek, addDays } from './utils.js';
+import { DATA, ensureDay } from './storage.js';
+import { state } from './state.js';
+
+const teamDateInput = document.getElementById('teamDate');
+const teamTable = document.getElementById('teamTable');
+const teamMeta = document.getElementById('teamMeta');
+
+export function initTeamView(){
+  teamDateInput.value = fmt(state.teamDate);
+  document.querySelectorAll('[data-team]').forEach(btn=>{
+    btn.onclick = ()=>{
+      document.querySelectorAll('[data-team]').forEach(x=>x.classList.remove('active'));
+      btn.classList.add('active');
+      state.teamMode = btn.dataset.team;
+      renderTeamView();
+    };
+  });
+  teamDateInput.onchange = ()=>{ state.teamDate = parse(teamDateInput.value); renderTeamView(); };
+}
+
+export function renderTeamView(){
+  if(!teamDateInput.value){ teamDateInput.value = fmt(new Date()); state.teamDate = new Date(); }
+  const thead = teamTable.querySelector('thead');
+  const tbody = teamTable.querySelector('tbody');
+  tbody.innerHTML = '';
+  let dates = [];
+  if(state.teamMode==='day'){
+    dates = [new Date(state.teamDate)];
+    thead.innerHTML = `<tr>
+      <th>Funcionário</th>
+      <th>${state.teamDate.toLocaleDateString('pt-BR', {weekday:'short', day:'2-digit', month:'2-digit'})}</th>
+    </tr>`;
+    teamMeta.textContent = 'Visão de 1 dia';
+  }else{
+    const start = startOfWeek(state.teamDate);
+    dates = Array.from({length:7}, (_,i)=>addDays(start,i));
+    thead.innerHTML = `<tr>
+      <th>Funcionário</th>
+      ${dates.map(d=>`<th>${d.toLocaleDateString('pt-BR',{weekday:'short',day:'2-digit',month:'2-digit'})}</th>`).join('')}
+    </tr>`;
+    teamMeta.textContent = `Semana de ${dates[0].toLocaleDateString('pt-BR')}`;
+  }
+
+  DATA.employees.forEach(emp=>{
+    const tds = dates.map(d=>{
+      ensureDay(fmt(d));
+      const info = DATA.schedules[fmt(d)];
+      const st = info.assignments[emp] || 'trabalho';
+      const hol = info.holiday ? ` <span class="tag hol">feriado</span>` : '';
+      const tag = `<span class="tag ${st==='folga'?'off':'work'}">${st}</span>${hol}`;
+      return `<td>${tag}</td>`;
+    }).join('');
+    tbody.insertAdjacentHTML('beforeend', `<tr><td><strong>${emp}</strong></td>${tds}</tr>`);
+  });
+}

--- a/src/js/userManagement.js
+++ b/src/js/userManagement.js
@@ -1,0 +1,88 @@
+import { DATA, saveData, ensureDay } from './storage.js';
+import { openModal } from './modal.js';
+
+export function addEmployee(name){
+  DATA.employees.push(name);
+  Object.keys(DATA.schedules).forEach(k=>{
+    ensureDay(k);
+    if(!(name in DATA.schedules[k].assignments)){
+      DATA.schedules[k].assignments[name] = 'trabalho';
+    }
+  });
+}
+export function renameEmployee(oldName, newName){
+  const idx = DATA.employees.indexOf(oldName);
+  if(idx>=0) DATA.employees[idx] = newName;
+  Object.values(DATA.schedules).forEach(day=>{
+    if(day.assignments && oldName in day.assignments){
+      day.assignments[newName] = day.assignments[oldName];
+      delete day.assignments[oldName];
+    }
+  });
+  DATA.swapRequests.forEach(r=>{
+    if(r.requester===oldName) r.requester=newName;
+    if(r.toEmployee===oldName) r.toEmployee=newName;
+  });
+}
+export function removeEmployee(name){
+  DATA.employees = DATA.employees.filter(e=>e!==name);
+  Object.values(DATA.schedules).forEach(day=>{
+    if(day.assignments && name in day.assignments){ delete day.assignments[name]; }
+  });
+  DATA.swapRequests.forEach(r=>{
+    if(r.requester===name || r.toEmployee===name){
+      if(r.status==='pendente') r.status='cancelada';
+    }
+  });
+}
+
+export function openUserManager(refresh){
+  const listHTML = DATA.employees.map(n=>`
+    <div class="row">
+      <div><strong>${n}</strong></div>
+      <div class="split">
+        <button class="btn" data-rename="${n}">Renomear</button>
+        <button class="btn" data-delete="${n}">Remover</button>
+      </div>
+    </div>
+  `).join('') || '<div class="empty">Sem funcionários.</div>';
+
+  openModal('Gerenciar Usuários', `
+    <div class="split">
+      <div style="flex:1">
+        <div class="label">Adicionar funcionário</div>
+        <div class="grid2">
+          <input type="text" id="newEmpName" placeholder="Nome completo">
+          <button class="btn primary" id="addEmpBtn">Adicionar</button>
+        </div>
+      </div>
+    </div>
+    <div class="list" style="margin-top:1rem">${listHTML}</div>
+    <div class="muted" style="margin-top:.6rem;font-size:.9rem">
+      Renomear atualiza a escala e as solicitações. Remover tira o funcionário de todas as escalas e <em>cancela</em> solicitações onde ele participa.
+    </div>
+  `);
+
+  document.getElementById('addEmpBtn').onclick = ()=>{
+    const name = document.getElementById('newEmpName').value.trim();
+    if(!name) return alert('Informe um nome.');
+    if(DATA.employees.includes(name)) return alert('Já existe um funcionário com esse nome.');
+    addEmployee(name); saveData(); refresh(); openUserManager(refresh);
+  };
+  document.querySelectorAll('[data-rename]').forEach(b=>{
+    b.onclick = ()=>{
+      const old = b.dataset.rename;
+      const novo = prompt(`Renomear "${old}" para:`, old)?.trim();
+      if(!novo || novo===old) return;
+      if(DATA.employees.includes(novo)) return alert('Já existe funcionário com esse nome.');
+      renameEmployee(old, novo); saveData(); refresh(); openUserManager(refresh);
+    };
+  });
+  document.querySelectorAll('[data-delete]').forEach(b=>{
+    b.onclick = ()=>{
+      const name = b.dataset.delete;
+      if(!confirm(`Remover "${name}"?`)) return;
+      removeEmployee(name); saveData(); refresh(); openUserManager(refresh);
+    };
+  });
+}

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -1,0 +1,19 @@
+export const fmt = (d)=> d.toISOString().slice(0,10);
+export const parse = (str)=> { const [y,m,da]=str.split('-').map(n=>+n); return new Date(y,m-1,da); };
+export const startOfWeek = (d)=> { const x=new Date(d); const day=(x.getDay()+6)%7; x.setDate(x.getDate()-day); x.setHours(0,0,0,0); return x; };
+export const addDays = (d, n)=> { const x=new Date(d); x.setDate(x.getDate()+n); return x; };
+export const monthLabel = (d)=> d.toLocaleDateString('pt-BR',{month:'long',year:'numeric'});
+export const dedupeByDate = (arr)=>{ const seen=new Set(); const out=[]; arr.forEach(x=>{ if(x?.date && !seen.has(x.date)){ seen.add(x.date); out.push(x); }}); return out; };
+
+export function toast(msg){
+  const el = document.createElement('div');
+  el.textContent = msg;
+  el.style.position='fixed'; el.style.bottom='20px'; el.style.left='50%';
+  el.style.transform='translateX(-50%)'; el.style.background='#1a2140';
+  el.style.border='1px solid #2a3154'; el.style.color='#e8ecf2';
+  el.style.padding='.6rem .8rem'; el.style.borderRadius='10px';
+  el.style.boxShadow='0 8px 30px rgba(0,0,0,.35)'; el.style.zIndex='1000';
+  document.body.appendChild(el);
+  setTimeout(()=>{ el.style.opacity='0'; el.style.transition='opacity .4s'; }, 1800);
+  setTimeout(()=> el.remove(), 2400);
+}


### PR DESCRIPTION
## Summary
- iniciar projeto npm com lite-server para desenvolvimento
- separar estilos e scripts em módulos seguindo princípios SOLID
- organizar lógica de calendário, feriados e trocas em serviços

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897e532bc14833193382dc77f3a333f