### PR TITLE
feat: improve mobile experience and PWA

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -5,12 +5,15 @@
     --radius:12px;
   }
   *{box-sizing:border-box}
+  img{max-width:100%;height:auto;display:block}
   body{margin:0;background:linear-gradient(180deg,#0b0e1a,#12162a);color:var(--text);font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif}
-  header{display:flex;gap:.75rem;align-items:center;justify-content:space-between;padding:1rem 1.2rem;border-bottom:1px solid #1f2440;position:sticky;top:0;background:#0f1221d9;backdrop-filter: blur(6px);z-index:10}
+  header{display:flex;flex-direction:column;gap:.75rem;align-items:flex-start;justify-content:center;padding:1rem 1.2rem;border-bottom:1px solid #1f2440;position:sticky;top:0;background:#0f1221d9;backdrop-filter: blur(6px);z-index:10}
+  @media(min-width:768px){header{flex-direction:row;align-items:center;justify-content:space-between}}
   .brand{display:flex;gap:.6rem;align-items:center}
   .brand .logo{width:34px;height:34px;border-radius:10px;background:linear-gradient(135deg,var(--brand),#9b6cff);display:grid;place-items:center;color:white;font-weight:700;box-shadow:var(--shadow)}
-  .controls{display:flex;flex-wrap:wrap;gap:.5rem;align-items:center}
-  .btn{border:1px solid #2a3154;background:#161a30;color:var(--text);padding:.55rem .8rem;border-radius:10px;cursor:pointer;transition:.15s;box-shadow:0 2px 0 #0b0e1a}
+  .controls{display:flex;flex-wrap:wrap;gap:.5rem;align-items:center;width:100%;overflow-x:auto}
+  @media(min-width:768px){.controls{width:auto;overflow:visible}}
+  .btn{border:1px solid #2a3154;background:#161a30;color:var(--text);padding:.55rem .8rem;border-radius:10px;cursor:pointer;transition:.15s;box-shadow:0 2px 0 #0b0e1a;min-height:44px;touch-action:manipulation;-webkit-tap-highlight-color:transparent}
   .btn:hover{transform:translateY(-1px);background:#1d2140}
   .btn.primary{background:linear-gradient(135deg,var(--brand),#9b6cff);border:none}
   .btn.ghost{background:transparent;border:1px dashed #2a3154}
@@ -18,9 +21,10 @@
   .btn-tab{background:#151931;border:none;padding:.5rem .9rem;cursor:pointer;color:#c7cbe0}
   .btn-tab.active{background:#27305b;color:#fff}
   select, input[type="date"], input[type="text"], textarea, input[type="number"]{
-    background:#12162a;border:1px solid #2a3154;color:var(--text);padding:.55rem .7rem;border-radius:10px;outline:none;min-width:140px
+    background:#12162a;border:1px solid #2a3154;color:var(--text);padding:.55rem .7rem;border-radius:10px;outline:none;min-width:140px;min-height:44px
   }
-  main{max-width:1200px;margin:1rem auto;padding:0 1rem 2rem}
+main{max-width:1200px;margin:1rem auto;padding:0 1rem 2rem;display:flex;flex-direction:column;gap:1rem}
+@media(min-width:960px){main{display:grid;grid-template-columns:1fr 1fr;align-items:flex-start}}
   .calendar{background:var(--card);border:1px solid #222846;border-radius:var(--radius);overflow:hidden;box-shadow:var(--shadow)}
   .cal-header{display:flex;justify-content:space-between;align-items:center;padding:1rem;border-bottom:1px solid #202643}
   .cal-grid{display:grid;grid-template-columns:repeat(7,1fr);gap:1px;background:var(--grid)}
@@ -35,8 +39,8 @@
   .cal-weekdays div{padding:.6rem;text-align:center;color:#96a0bb;font-weight:600}
   .muted{color:#9aa3b2}
   .today{outline:2px solid var(--brand);outline-offset:-2px;border-radius:8px}
-  .side{margin-top:1rem;display:grid;grid-template-columns:1.1fr .9fr;gap:1rem}
-  @media(max-width:960px){.side{grid-template-columns:1fr}}
+  .side{margin-top:1rem;display:flex;flex-direction:column;gap:1rem}
+  @media(min-width:960px){.side{display:grid;grid-template-columns:1.1fr .9fr;margin-top:0}}
   .panel{background:var(--card);border:1px solid #222846;border-radius:var(--radius);padding:1rem;box-shadow:var(--shadow)}
   .panel h3{margin:.2rem 0 1rem;font-size:1.05rem}
   .list{display:flex;flex-direction:column;gap:.5rem}

--- a/src/index.html
+++ b/src/index.html
@@ -3,7 +3,10 @@
 <head>
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+<meta name="description" content="Aplicativo de escalas e feriados para funcionários" />
+<meta name="theme-color" content="#6c7cff" />
 <title>Escalas & Feriados • Folgas</title>
+<link rel="manifest" href="./manifest.webmanifest" />
 <link rel="stylesheet" href="./css/styles.css">
 </head>
 <body>
@@ -182,6 +185,6 @@
     </div>
   </div>
 
-  <script type="module" src="./js/main.js"></script>
+  <script type="module" defer src="./js/main.js"></script>
 </body>
 </html>

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -8,7 +8,6 @@ import { refreshRequests, refreshAdminRequests } from './swap.js';
 import { initTeamView, renderTeamView } from './teamView.js';
 import { initSettings } from './settings.js';
 import { initAuth, showLogin, afterLogin, updateRoleUI, refreshEmployeeSelect } from './auth.js';
-import { openUserManager } from './userManagement.js';
 import { fmt } from './utils.js';
 
 // navigation buttons
@@ -91,7 +90,11 @@ editScaleBtn.onclick = ()=>{
 
 // manage users
 const manageUsersBtn = document.getElementById('manageUsersBtn');
-manageUsersBtn.onclick = ()=>{ if(!isAdmin()) return; openUserManager(refreshAllUI); };
+manageUsersBtn.onclick = async ()=>{
+  if(!isAdmin()) return;
+  const { openUserManager } = await import('./userManagement.js');
+  openUserManager(refreshAllUI);
+};
 
 // sync buttons
 document.getElementById('syncAllBtn').onclick = ()=>{ if(!isAdmin()) return; syncAll(state.currentDate.getFullYear()); };
@@ -123,6 +126,12 @@ renderTeamView();
 if(!SESSION){ showLogin(); } else { afterLogin(); }
 
 syncBR(new Date().getFullYear()).catch(()=>{});
+
+if('serviceWorker' in navigator){
+  window.addEventListener('load', ()=>{
+    navigator.serviceWorker.register('./sw.js');
+  });
+}
 
 // accessibility
 document.addEventListener('keydown', (e)=>{

--- a/src/manifest.webmanifest
+++ b/src/manifest.webmanifest
@@ -1,0 +1,9 @@
+{
+  "name": "Escalas & Feriados",
+  "short_name": "Escalas",
+  "start_url": "./index.html",
+  "display": "standalone",
+  "background_color": "#0f1221",
+  "theme_color": "#6c7cff",
+  "description": "Aplicativo de escalas e feriados para funcionários"
+}

--- a/src/sw.js
+++ b/src/sw.js
@@ -1,0 +1,19 @@
+const CACHE_NAME = 'escalas-cache-v1';
+const ASSETS = [
+  './',
+  './index.html',
+  './css/styles.css',
+  './js/main.js'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(ASSETS))
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(resp => resp || fetch(event.request))
+  );
+});


### PR DESCRIPTION
## Summary
- make layout mobile-first with responsive header and controls
- lazy-load user manager and register service worker for offline
- add basic PWA manifest and theme metadata

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897f15a64948331958a63487604d4b0