### PR TITLE
ci: automatiza versionamento v0.0.* e release com publish .NET 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,111 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - master
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  create-tag:
+    name: Criar tag v0.0.*
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Criar próxima tag v0.0.*
+        id: next_tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --tags --force
+
+          EXISTING_TAG="$(git tag --points-at HEAD 'v0.0.*' | head -n 1 || true)"
+          if [[ -n "${EXISTING_TAG}" ]]; then
+            echo "A HEAD já possui a tag ${EXISTING_TAG}. Nenhuma nova tag será criada."
+            echo "created=false" >> "$GITHUB_OUTPUT"
+            echo "tag=${EXISTING_TAG}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          LATEST_TAG="$(git tag -l 'v0.0.*' --sort=-v:refname | head -n 1 || true)"
+          if [[ -z "${LATEST_TAG}" ]]; then
+            NEXT_TAG="v0.0.1"
+          else
+            PATCH="${LATEST_TAG#v0.0.}"
+            NEXT_PATCH=$((PATCH + 1))
+            NEXT_TAG="v0.0.${NEXT_PATCH}"
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git tag "${NEXT_TAG}"
+          git push origin "${NEXT_TAG}"
+
+          echo "created=true" >> "$GITHUB_OUTPUT"
+          echo "tag=${NEXT_TAG}" >> "$GITHUB_OUTPUT"
+
+  publish-and-release:
+    name: Publicar e criar Release
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET 8
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Localizar projeto .csproj
+        id: locate_project
+        shell: bash
+        run: |
+          set -euo pipefail
+          PROJECT_FILE="$(find . -maxdepth 8 -name '*.csproj' | head -n 1 || true)"
+          if [[ -z "${PROJECT_FILE}" ]]; then
+            echo "Nenhum arquivo .csproj foi encontrado no repositório."
+            exit 1
+          fi
+          echo "project_file=${PROJECT_FILE}" >> "$GITHUB_OUTPUT"
+
+      - name: Restore
+        run: dotnet restore "${{ steps.locate_project.outputs.project_file }}"
+
+      - name: Publish (Release | win-x64 | self-contained)
+        run: |
+          dotnet publish "${{ steps.locate_project.outputs.project_file }}" \
+            --configuration Release \
+            --runtime win-x64 \
+            --self-contained true \
+            --output ./artifacts/publish
+
+      - name: Gerar zip do executável
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p ./artifacts/release
+          zip -r "./artifacts/release/BuscaPreco-${{ github.ref_name }}-win-x64.zip" ./artifacts/publish
+
+      - name: Criar GitHub Release e anexar binário
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: Release ${{ github.ref_name }}
+          generate_release_notes: true
+          files: |
+            ./artifacts/release/BuscaPreco-${{ github.ref_name }}-win-x64.zip


### PR DESCRIPTION
### Motivation
- O projeto foi migrado para .NET 8 e precisa de um fluxo CI que automatize versionamento e publicação para builds Windows self-contained.
- É necessário garantir tags no formato `v0.0.*` e criar Releases oficiais no GitHub com o binário zipado anexado.

### Description
- Adicionado o workflow completo em `.github/workflows/ci.yml` com gatilhos em `push` para `main/master`, `push` de tags `v*` e `workflow_dispatch`.
- Incluído `permissions: contents: write` para permitir criação de tags e Releases via Actions.
- Implementado job `create-tag` que roda ao enviar para `main`/`master`, busca a última tag `v0.0.*`, gera a próxima no padrão `v0.0.<patch+1>` (inicia em `v0.0.1` se não existir) e evita duplicar tag se o commit já estiver tagueado.
- Implementado job `publish-and-release` que é disparado em push de tags `v*`, faz `setup-dotnet@v4` para .NET 8, localiza o primeiro `.csproj`, executa `dotnet publish` com `--configuration Release --runtime win-x64 --self-contained true --output ./artifacts/publish`, empacota em `BuscaPreco-<tag>-win-x64.zip` e cria a Release com `softprops/action-gh-release@v2` anexando o zip.

### Testing
- Verificação do conteúdo do workflow com `sed -n '1,260p' .github/workflows/ci.yml` foi executada com sucesso.
- Impressão paginada do arquivo com `nl -ba .github/workflows/ci.yml | sed -n '1,260p'` foi executada com sucesso para revisão do YAML.
- Estado do repositório checado com `git status --short --branch` foi executado com sucesso para confirmar mudança de trabalho.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5f6c663a08331b03ab64068c9f3c7)